### PR TITLE
Registration setup

### DIFF
--- a/personal/serializers.py
+++ b/personal/serializers.py
@@ -30,10 +30,8 @@ class SchoolShortSerializer(serializers.ModelSerializer):
 class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
-        read_only_fields = ('first_name', 'last_name')
+        # read_only_fields = ('first_name', 'last_name')
         exclude = ('user',)
-
-    email = serializers.EmailField(source='user.email')
 
 
 class ProfileShortSerializer(serializers.ModelSerializer):

--- a/personal/serializers.py
+++ b/personal/serializers.py
@@ -30,7 +30,15 @@ class SchoolShortSerializer(serializers.ModelSerializer):
 class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
-        # read_only_fields = ('first_name', 'last_name')
+        read_only_fields = ('first_name', 'last_name', 'email')
+        exclude = ('user',)
+
+        email = serializers.EmailField(source='user.email')
+
+
+class ProfileCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Profile
         exclude = ('user',)
 
 

--- a/personal/signals.py
+++ b/personal/signals.py
@@ -1,16 +1,16 @@
-from django.db.models.signals import post_save
+# from django.db.models.signals import post_save
 
-from user.models import User
-from personal.models import Profile
-
-
-def callback(sender, instance, **kwargs):
-    # pylint: disable=W0613
-
-    Profile.objects.get_or_create(
-        user=instance, defaults={'year_of_graduation': 2000,
-                                 'school_id': 1, 'first_name': '', 'last_name': ''})
-    instance.profile.save()
+# from user.models import User
+# from personal.models import Profile
 
 
-post_save.connect(callback, sender=User)
+# def callback(sender, instance, **kwargs):
+#     # pylint: disable=W0613
+
+#     Profile.objects.get_or_create(
+#         user=instance, defaults={'year_of_graduation': 2000,
+#                                  'school_id': 1, 'first_name': '', 'last_name': ''})
+#     instance.profile.save()
+
+
+# post_save.connect(callback, sender=User)

--- a/personal/tests.py
+++ b/personal/tests.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
 from django.test import TestCase
-from user.models import User
+# from user.models import User
 from personal.models import County, District, School
 from personal.serializers import CountySerializer, DistrictSerializer, SchoolSerializer
 
@@ -14,12 +14,13 @@ class TestProfile(TestCase):
             name="Testovací okres", county=county)
         School.objects.create(name="Testovacia škola", district=district)
 
-    def test_create_user_without_profile(self):
-        user = User()
-        user.save()
+    # def test_create_user_without_profile(self):
+    #     user = User()
+    #     user.save()
 
-        self.assertTrue(hasattr(user, 'profile'),
-                        msg="Profile pre Usera nebol vytvorený automaticky.")
+    #     self.assertTrue(hasattr(user, 'profile'),
+    #                     msg="Profile pre Usera nebol vytvorený automaticky.")
+
 
 class TestCounty(TestCase):
 
@@ -31,12 +32,13 @@ class TestCounty(TestCase):
         self.assertTrue(isinstance(mod, County))
         self.assertEqual(mod.__str__(), 'Testovaci kraj')
 
+
 class CountyViewsTest(APITestCase):
 
     def setUp(self):
         self.counties = [County.objects.create(name="Košický kraj"),
-            County.objects.create(name="Prešovský kraj"),
-            County.objects.create(name="Bratislavský kraj")]
+                         County.objects.create(name="Prešovský kraj"),
+                         County.objects.create(name="Bratislavský kraj")]
 
     URL_PREFIX = '/personal/counties'
 
@@ -52,16 +54,18 @@ class CountyViewsTest(APITestCase):
                 response.data
             )
 
+
 class TestDistrict(TestCase):
 
     def setUp(self):
         county = County.objects.create(name="Testovací kraj")
-        return District.objects.create(name='Testovaci okres',county=county)
+        return District.objects.create(name='Testovaci okres', county=county)
 
     def test_district_check_title(self):
         mod = self.setUp()
         self.assertTrue(isinstance(mod, District))
         self.assertEqual(mod.__str__(), 'Testovaci okres')
+
 
 class DistrictViewsTest(APITestCase):
 
@@ -69,8 +73,9 @@ class DistrictViewsTest(APITestCase):
         county1 = County.objects.create(name="Košický kraj")
         county2 = County.objects.create(name="Prešovský kraj")
         self.districts = [District.objects.create(name="Gelnica", county=county1),
-            District.objects.create(name="Rožňava", county=county1),
-            District.objects.create(name="Sabinov", county=county2)]
+                          District.objects.create(
+                              name="Rožňava", county=county1),
+                          District.objects.create(name="Sabinov", county=county2)]
 
     URL_PREFIX = '/personal/districts'
 
@@ -103,34 +108,38 @@ class DistrictViewsTest(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(1, len(response.data))
         self.assertIn(
-                DistrictSerializer(instance=self.districts[2]).data,
-                response.data
-            )
+            DistrictSerializer(instance=self.districts[2]).data,
+            response.data
+        )
+
 
 class TestSchoolWithoutAddress(TestCase):
 
     def setUp(self):
         county = County.objects.create(name="Testovací kraj")
-        district = District.objects.create(name="Testovací okres",county=county)
-        return School.objects.create(name='Gymnázium, Poštová 9',district=district)
+        district = District.objects.create(
+            name="Testovací okres", county=county)
+        return School.objects.create(name='Gymnázium, Poštová 9', district=district)
 
     def test_school_check_title(self):
         mod = self.setUp()
         self.assertTrue(isinstance(mod, School))
         self.assertEqual(mod.__str__(), 'Gymnázium, Poštová 9')
 
+
 class TestSchoolWithAddress(TestCase):
 
     def setUp(self):
         county = County.objects.create(name="Testovací kraj")
-        district = District.objects.create(name="Testovací okres",county=county)
+        district = District.objects.create(
+            name="Testovací okres", county=county)
         return School.objects.create(
             name='Gymnázium',
             district=district,
             street='Poštová 9',
             city='Košice',
             zip_code='04001'
-            )
+        )
 
     def test_school_check_title(self):
         mod = self.setUp()
@@ -145,7 +154,9 @@ class TestSchoolWithAddress(TestCase):
     def test_stitok(self):
         mod = self.setUp()
         self.assertTrue(isinstance(mod, School))
-        self.assertEqual(mod.stitok, '\\stitok{Gymnázium}{Košice}{040 01}{Poštová 9}')
+        self.assertEqual(
+            mod.stitok, '\\stitok{Gymnázium}{Košice}{040 01}{Poštová 9}')
+
 
 class SchoolViewsTest(APITestCase):
 
@@ -160,22 +171,22 @@ class SchoolViewsTest(APITestCase):
                 street='Poštová 9',
                 city='Košice',
                 zip_code='04001'
-                ),
+            ),
             School.objects.create(
                 name='Gymnázium',
                 district=district2,
                 street='Alejová 1',
                 city='Košice',
                 zip_code='04149'
-                ),
+            ),
             School.objects.create(
                 name='Gymnázium',
                 district=district2,
                 street='Opatovská cesta 7',
                 city='Košice',
                 zip_code='04001'
-                )
-            ]
+            )
+        ]
 
     URL_PREFIX = '/personal/schools'
 
@@ -192,16 +203,18 @@ class SchoolViewsTest(APITestCase):
             )
 
     def test_filter_schools(self):
-        response = self.client.get(self.URL_PREFIX + '/?district=1', {}, 'json')
+        response = self.client.get(
+            self.URL_PREFIX + '/?district=1', {}, 'json')
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(1, len(response.data))
         self.assertIn(
-                SchoolSerializer(instance=self.schools[0]).data,
-                response.data
-            )
+            SchoolSerializer(instance=self.schools[0]).data,
+            response.data
+        )
 
-        response = self.client.get(self.URL_PREFIX + '/?district=2', {}, 'json')
+        response = self.client.get(
+            self.URL_PREFIX + '/?district=2', {}, 'json')
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(2, len(response.data))

--- a/user/adapters.py
+++ b/user/adapters.py
@@ -1,10 +1,17 @@
-# from django.conf import settings
 from allauth.account.adapter import DefaultAccountAdapter
+from django.core.mail import send_mail
 
 
 class CustomAccountAdapter(DefaultAccountAdapter):
 
     def send_mail(self, template_prefix, email, context):
-        print("--------------------")
-        print("Email poslany. Urcite???")
-        print("--------------------")
+        # Táto funkcia by mala poslať email s linkom na aktiváciu. Na to je ale potrebné mať na
+        # na frontende stránku, ktorá z linku vyextrahuje 'key' a pošle ho na api endpoint
+        # zabezpečujúci aktiváciu. Zatiaľ tento 'key' je len priložený v tele emailu
+
+        # Api endpoint na aktiváciu: /user/registration/verify-email/
+
+        # Na znení mailu sa dohodneme neskôr
+
+        send_mail('Konfirmácia emailovej adresy',
+                  f'Key = {context["key"]}', 'no-reply@strom.sk', [context['user'].email])

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -9,7 +9,7 @@ from allauth.utils import email_address_exists
 
 from user.models import User, TokenModel
 from personal.models import Profile
-from personal.serializers import ProfileSerializer
+from personal.serializers import ProfileCreateSerializer
 
 
 class LoginSerializer(serializers.Serializer):
@@ -79,7 +79,7 @@ class UserDetailsSerializer(serializers.ModelSerializer):
     Serializer pre User model spolu s Profile modelom
     """
 
-    profile = ProfileSerializer(label='')
+    profile = ProfileCreateSerializer(label='')
 
     def validate_username(self, username):
         username = get_adapter().clean_username(username)
@@ -126,7 +126,7 @@ class RegisterSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True)
     password1 = serializers.CharField(write_only=True)
     password2 = serializers.CharField(write_only=True)
-    profile = ProfileSerializer()
+    profile = ProfileCreateSerializer(label="")
 
     def validate_email(self, email):
         email = get_adapter().clean_email(email)

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -2,10 +2,9 @@ from django.contrib.auth import authenticate, get_user_model
 
 from rest_framework import serializers, exceptions
 
-from allauth.account import app_settings as allauth_settings
 from allauth.account.adapter import get_adapter
 from allauth.account.utils import setup_user_email
-from allauth.utils import (email_address_exists, get_username_max_length)
+from allauth.utils import email_address_exists
 
 
 from user.models import User, TokenModel
@@ -121,6 +120,9 @@ class UserDetailsSerializer(serializers.ModelSerializer):
 
 
 class RegisterSerializer(serializers.Serializer):
+    #pylint: disable=w0223
+    #pylint: disable=w0221
+    #pylint: disable=w0201
     email = serializers.EmailField(required=True)
     password1 = serializers.CharField(write_only=True)
     password2 = serializers.CharField(write_only=True)
@@ -159,6 +161,7 @@ class RegisterSerializer(serializers.Serializer):
 
 
 class VerifyEmailSerializer(serializers.Serializer):
+    #pylint: disable=w0223
     key = serializers.CharField()
 
 

--- a/user/urls.py
+++ b/user/urls.py
@@ -7,7 +7,7 @@ from django.contrib.auth.views import (  # LogoutView, LoginView,
     PasswordResetView)
 from django.urls import path, reverse_lazy
 
-from user.views import LoginView, LogoutView, UserDetailsView
+from user.views import LoginView, LogoutView, UserDetailsView, RegisterView, VerifyEmailView
 from user.views import UserProfileView, profile_update, register, verify
 
 app_name = 'user'
@@ -17,10 +17,13 @@ urlpatterns = [
     path('login/', LoginView.as_view(), name='login'),
     path('logout/', LogoutView.as_view(), name='logout'),
     path('details/', UserDetailsView.as_view(), name='user-details'),
+    path('registration/', RegisterView.as_view(), name='register'),
+    path('registration/verify-email/',
+         VerifyEmailView.as_view(), name='verify-email'),
 
     # Url ktoré neboli zatiaľ prepísané do restu.
 
-    path('register/', register, name='register'),
+    path('register/', register, name='register-to-be-deleted'),
     path('verify/<str:uidb64>/<str:token>/', verify, name='verify'),
     path('profile/update/', profile_update, name='profile-update'),
     path('profile/<int:pk>/', UserProfileView.as_view(), name='profile-detail'),

--- a/user/views.py
+++ b/user/views.py
@@ -27,7 +27,12 @@ from competition.models import Grade, Profile
 from personal.models import District, School
 from user.forms import NameUpdateForm, UserCreationForm
 from user.models import User, TokenModel
-from user.serializers import LoginSerializer, TokenSerializer, UserDetailsSerializer, RegisterSerializer, VerifyEmailSerializer
+from user.serializers import (
+    LoginSerializer,
+    TokenSerializer,
+    UserDetailsSerializer,
+    RegisterSerializer,
+    VerifyEmailSerializer)
 from user.tokens import email_verification_token_generator
 
 
@@ -119,18 +124,20 @@ class UserDetailsView(RetrieveUpdateAPIView):
 
 
 class RegisterView(CreateAPIView):
+    #pylint: disable=w0212
+    #pylint: disable=E1101
     serializer_class = RegisterSerializer
     permission_classes = [AllowAny, ]
     token_model = TokenModel
 
     @sensitive_post_parameters_m
     def dispatch(self, *args, **kwargs):
-        return super(RegisterView, self).dispatch(*args, **kwargs)
+        return super().dispatch(*args, **kwargs)
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        user = self.perform_create(serializer)
+        self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
 
         return Response({"detail": "Verifikačný email odoslaný."},
@@ -147,6 +154,7 @@ class RegisterView(CreateAPIView):
 
 
 class VerifyEmailView(APIView, ConfirmEmailView):
+    #pylint: disable=w0221
     permission_classes = (AllowAny,)
     allowed_methods = ('POST', 'OPTIONS', 'HEAD')
 


### PR DESCRIPTION
Vytvorene api endpointy:

- /user/registration/ - api endpoint ktory vytvori User a Profile zo zadanych udajov, vytvori email v modeli  EmailAddress ktory je definovany v allauth appke. Tento email je nastaveny ako primarny pre uzivatela a neovereny. Dalej sa posle verifikacny email (zatial len do priecinku emails) ktory aktualne obsahuje len "key" na verifikaciu. Ked bude existovat FE stranka, zmeni sa to na verifikacny link.
- /user/registration/verify-email/ - Tu sa da zadat "key" ktory dosiel mailom a email sa verifikuje.

Zmeny:
- /user/login/ teraz funguje len pre ucty ktore maju email v EmailAddress modeli a teda zatial funguje len pre novo vytvorene ucty ale nie pre ucty z fixtures pretoze tieto ucty tam ten email zatial nemaju. Django admin login sa ale da pouzivat aj bez toho a aj ked ucet nie je overeny.
- Zrusil som zatial on_save signal pre vytvorenie profilu lebo ho zatial netreba (mozno ani nikdy nebude) a preto je zatial zakomentovany test ktory ho testoval.


