### PR TITLE
Writable nested fields

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -1,5 +1,6 @@
 from django_typomatic import ts_interface
 from rest_framework import serializers
+from drf_writable_nested.serializers import WritableNestedModelSerializer
 
 from cms import models
 
@@ -16,16 +17,9 @@ class PostLinkSerializer(serializers.ModelSerializer):
         exclude = ['post']
 
 @ts_interface(context='cms')
-class PostSerializer(serializers.ModelSerializer):
+class PostSerializer(WritableNestedModelSerializer):
     links = PostLinkSerializer(many=True)
 
     class Meta:
         model = models.Post
         fields = '__all__'
-
-    def create(self, validated_data):
-        post_links_data = validated_data.pop('links')
-        post = models.Post.objects.create(**validated_data)
-        for post_link_data in post_links_data:
-            models.PostLink.objects.create(post=post, **post_link_data)
-        return post

--- a/prod-requirements.txt
+++ b/prod-requirements.txt
@@ -10,3 +10,4 @@ Pillow==8.1.1
 python-magic==0.4.18
 pytz==2020.1
 sqlparse==0.3.1
+drf-writable-nested==0.6.3

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -158,17 +158,17 @@ class RegisterSerializer(serializers.Serializer):
                 'Musíš podvrdiť, že si si vedomý spracovania osobných údajov.')
         return profile
 
-    def validate(self, data):
-        if data['password1'] != data['password2']:
+    def validate(self, attr):
+        if attr['password1'] != attr['password2']:
             raise serializers.ValidationError("Zadané heslá sa nezhodujú.")
 
         # ak je zadana skola "ina skola", musi byt nejaky description skoly
-        if (data['profile']['school'].code == self.OTHER_SCHOOL_CODE and
-                len(data['new_school_description']) == 0):
+        if (attr['profile']['school'].code == self.OTHER_SCHOOL_CODE and
+                len(attr['new_school_description']) == 0):
             raise serializers.ValidationError(
                 'Musíš zadať popis tvojej školy.')
 
-        return data
+        return attr
 
     def get_cleaned_data(self):
         return {

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -158,17 +158,17 @@ class RegisterSerializer(serializers.Serializer):
                 'Musíš podvrdiť, že si si vedomý spracovania osobných údajov.')
         return profile
 
-    def validate(self, attr):
-        if attr['password1'] != attr['password2']:
+    def validate(self, attrs):
+        if attrs['password1'] != attrs['password2']:
             raise serializers.ValidationError("Zadané heslá sa nezhodujú.")
 
         # ak je zadana skola "ina skola", musi byt nejaky description skoly
-        if (attr['profile']['school'].code == self.OTHER_SCHOOL_CODE and
-                len(attr['new_school_description']) == 0):
+        if (attrs['profile']['school'].code == self.OTHER_SCHOOL_CODE and
+                len(attrs['new_school_description']) == 0):
             raise serializers.ValidationError(
                 'Musíš zadať popis tvojej školy.')
 
-        return attr
+        return attrs
 
     def get_cleaned_data(self):
         return {


### PR DESCRIPTION
pri POST (create) a PATCH (update) requestoch na Postoch vracal BE takuto chybu:
```
AssertionError: The `.update()` method does not support writable nested fields by default.
Write an explicit `.update()` method for serializer `cms.serializers.PostSerializer`, or set `read_only=True` on nested serializer fields.
```
po chvilke googlenia som nasiel tento modul: https://pypi.org/project/drf-writable-nested/
ked som ho vyskusal, zda sa poriesil tieto problemy so serializovanim poli. ja tomu ale az tak nerozumiem, tak niekto prosim zvalidujte, ci to dava zmysel, a ci to vieme nasadit aj na ostatne serializery s poliami - napr. Competition. ale to sa mozno lisi:
- Post ma field `links` a myslim, ze tie dava zmysel managovat rovno cez request na `/cms/post`
- Competition ma field `event_set`, no mame osobitny endpoint na managovanie eventov, tak netusim, co posielat pri PATCH na `/competition/competition` a ako sa to ma spravat