### PR TITLE
CORS: Allow calling BE from browser on localhost

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ dill==0.3.9
 dj-rest-auth==5.0.2
 Django==4.2.17
 django-allauth==0.58.2
+django-cors-headers==4.6.0
 django-filter==23.5
 django-rest-swagger==2.2.0
 django-sendfile2==0.7.1

--- a/webstrom/settings.py
+++ b/webstrom/settings.py
@@ -19,6 +19,11 @@ CSRF_TRUSTED_ORIGINS = [
     'https://localhost:3000'
 ]
 
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:3000',
+]
+CORS_ALLOW_CREDENTIALS = True
+
 # Application definition
 
 DJANGO_APPS = [
@@ -39,6 +44,7 @@ THIRD_PARTY_APPS = [
     'dj_rest_auth',
     'django_filters',
     'rest_framework_swagger',
+    "corsheaders",
 ]
 
 LOCAL_APPS = [
@@ -61,6 +67,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'allauth.account.middleware.AccountMiddleware',
+    "corsheaders.middleware.CorsMiddleware",
 ]
 
 ROOT_URLCONF = 'webstrom.urls'


### PR DESCRIPTION
bez tohto neviem lokalne volat BE z browsru. potrebujeme to, kedze chceme public backend pod `/api` a zbavit sa hopu na next.js server-side.

este asi zistime, ci bude treba explicitne pridat aj test.strom.sk alebo tak... to neviem, ako funguje, ale localhost mi toto riesi.

current:
browser -> /api (next.js server-side route, rewrite) -> interny BE localhost

target:
browser -> /api (nginx proxy) -> BE