### PR TITLE
Add competition_type filters on EventViewSet & CompetitionViewSet

### DIFF
--- a/competition/views.py
+++ b/competition/views.py
@@ -121,12 +121,20 @@ class CompetitionViewSet(mixins.RetrieveModelMixin,
                          mixins.ListModelMixin,
                          viewsets.GenericViewSet):
     """Naše aktivity"""
+    class CompetitionFilterSet(FilterSet):
+        competition_type_exclude = NumberFilter(
+            field_name='competition_type', exclude=True)
+
+        class Meta:
+            model = Competition
+            fields = ['slug', 'sites', 'competition_type']
+
     queryset = Competition.objects.all()
     serializer_class = CompetitionSerializer
     permission_classes = (CompetitionRestrictedPermission,)
     filter_backends = [DjangoFilterBackend,
                        UnaccentSearchFilter, filters.OrderingFilter]
-    filterset_fields = ['slug', 'sites', 'competition_type']
+    filterset_class = CompetitionFilterSet
     search_fields = ['name']
     ordering_fields = ['name', 'start_year', 'competition_type']
     ordering = ['start_year']

--- a/competition/views.py
+++ b/competition/views.py
@@ -122,7 +122,10 @@ class CompetitionViewSet(mixins.RetrieveModelMixin,
     """Naše aktivity"""
     class CompetitionFilterSet(FilterSet):
         competition_type_exclude = ModelChoiceFilter(
-            field_name='competition_type', exclude=True)
+            field_name='competition_type',
+            queryset=CompetitionType.objects.all(),
+            exclude=True
+        )
 
         class Meta:
             model = Competition

--- a/competition/views.py
+++ b/competition/views.py
@@ -13,7 +13,7 @@ from django.core.files import File
 from django.db.models.manager import BaseManager
 from django.http import FileResponse, Http404, HttpResponse
 from django_filters import (BooleanFilter, Filter, FilterSet,
-                             ModelChoiceFilter, NumberFilter)
+                            ModelChoiceFilter, NumberFilter)
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions, filters, mixins, status, viewsets
 from rest_framework.decorators import action
@@ -1017,10 +1017,15 @@ class EventViewSet(ModelViewSetWithSerializerContext):
 
         grade = SuitableForGradeFilter(queryset=Grade.objects.all())
         future = UpcomingFilter(field_name='end')
-        competition_type = NumberFilter(
-            field_name='competition__competition_type')
-        competition_type_exclude = NumberFilter(
-            field_name='competition__competition_type', exclude=True)
+        competition_type = ModelChoiceFilter(
+            field_name='competition__competition_type',
+            queryset=CompetitionType.objects.all()
+        )
+        competition_type_exclude = ModelChoiceFilter(
+            field_name='competition__competition_type',
+            queryset=CompetitionType.objects.all(),
+            exclude=True
+        )
 
         class Meta:
             model = Event

--- a/competition/views.py
+++ b/competition/views.py
@@ -12,8 +12,7 @@ from django.core.files import File
 # pylint: disable=unused-argument
 from django.db.models.manager import BaseManager
 from django.http import FileResponse, Http404, HttpResponse
-from django_filters import (BooleanFilter, Filter, FilterSet,
-                            ModelChoiceFilter, NumberFilter)
+from django_filters import BooleanFilter, Filter, FilterSet, ModelChoiceFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions, filters, mixins, status, viewsets
 from rest_framework.decorators import action
@@ -122,7 +121,7 @@ class CompetitionViewSet(mixins.RetrieveModelMixin,
                          viewsets.GenericViewSet):
     """Naše aktivity"""
     class CompetitionFilterSet(FilterSet):
-        competition_type_exclude = NumberFilter(
+        competition_type_exclude = ModelChoiceFilter(
             field_name='competition_type', exclude=True)
 
         class Meta:

--- a/competition/views.py
+++ b/competition/views.py
@@ -12,7 +12,8 @@ from django.core.files import File
 # pylint: disable=unused-argument
 from django.db.models.manager import BaseManager
 from django.http import FileResponse, Http404, HttpResponse
-from django_filters import BooleanFilter, Filter, FilterSet, ModelChoiceFilter
+from django_filters import (BooleanFilter, Filter, FilterSet,
+                             ModelChoiceFilter, NumberFilter)
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions, filters, mixins, status, viewsets
 from rest_framework.decorators import action
@@ -1008,6 +1009,10 @@ class EventViewSet(ModelViewSetWithSerializerContext):
 
         grade = SuitableForGradeFilter(queryset=Grade.objects.all())
         future = UpcomingFilter(field_name='end')
+        competition_type = NumberFilter(
+            field_name='competition__competition_type')
+        competition_type_exclude = NumberFilter(
+            field_name='competition__competition_type', exclude=True)
 
         class Meta:
             model = Event


### PR DESCRIPTION
## Summary
Adds filter support so the React admin can pre-filter events and competitions by competition type:

- **EventViewSet**: \`competition_type\` (exact) and \`competition_type_exclude\` (negative), both traversing \`competition__competition_type\`.
- **CompetitionViewSet**: \`competition_type_exclude\` (negative, mirrors the existing positive \`competition_type\` filter).

Together these unblock hiding seminars from the Event list and from Competition pickers on Event Create/Edit in the React admin.

## Test plan
- [ ] \`GET /competition/event/?competition_type=1\` → only events whose competition has type 1
- [ ] \`GET /competition/event/?competition_type_exclude=0\` → only events whose competition is not a seminar
- [ ] \`GET /competition/competition/?competition_type_exclude=0\` → only non-seminar competitions
- [ ] Existing filters (\`slug\`, \`sites\`, \`competition_type\`, \`school_year\`, \`season_code\`, \`location\`, \`competition\`, \`grade\`, \`future\`) still work